### PR TITLE
New hooks to determine if a player could drive

### DIFF
--- a/lua/entities/lvs_base/sv_pod.lua
+++ b/lua/entities/lvs_base/sv_pod.lua
@@ -62,8 +62,9 @@ function ENT:SetPassenger( ply )
 
 	local AI = self:GetAI()
 	local DriverSeat = self:GetDriverSeat()
+	local AllowedToBeDriver = hook.Run( "LVS.CanPlayerDrive", ply, self ) ~= false
 
-	if IsValid( DriverSeat ) and not IsValid( DriverSeat:GetDriver() ) and not ply:KeyDown( IN_WALK ) and not AI then
+	if IsValid( DriverSeat ) and not IsValid( DriverSeat:GetDriver() ) and not ply:KeyDown( IN_WALK ) and not AI and AllowedToBeDriver then
 		ply:EnterVehicle( DriverSeat )
 	else
 		local Seat = NULL
@@ -86,7 +87,11 @@ function ENT:SetPassenger( ply )
 		else
 			if IsValid( DriverSeat ) then
 				if not IsValid( self:GetDriver() ) and not AI then
-					ply:EnterVehicle( DriverSeat )
+					if AllowedToBeDriver then
+						ply:EnterVehicle( DriverSeat )
+					else
+						hook.Run( "LVS.OnPlayerCannotDrive", ply, self )
+					end
 				end
 			else
 				self:EmitSound( "doors/default_locked.wav" )

--- a/lua/lvs_framework/autorun/sv_switcher.lua
+++ b/lua/lvs_framework/autorun/sv_switcher.lua
@@ -14,6 +14,11 @@ hook.Add( "PlayerButtonDown", "!!!lvsSeatSwitcherButtonDown", function( ply, but
 			end
 		else
 			if IsValid( vehicle:GetDriver() ) or vehicle:GetAI() then return end
+	
+			if hook.Run( "LVS.CanPlayerDrive", ply, vehicle ) == false then
+				hook.Run( "LVS.OnPlayerCannotDrive", ply, vehicle )
+				return
+			end
 
 			ply:ExitVehicle()
 


### PR DESCRIPTION
Hello, added new hooks to **determine** if a player **could drive** a vehicle:
- LVS.CanPlayerDrive
- LVS.OnPlayerCannotDrive

This could be useful for driver license systems and etc., I personally use these hooks to limit the ability to use vehicles for untrained soldiers on the Star Wars RP server.

### Example:
```lua
local function canPlayerControlVehicle(ply, vehicle)
    if (not IsValid(vehicle)) then return false end

    local class = vehicle:GetClass()
    local isAir = mopp.cfg.AirVehicles[class]
    local isLand = mopp.cfg.LandVehicles[class]

    local allowed

    if (isAir) then
        allowed = ply:HasRight("air")
    else
        allowed = ply:HasRight("land")
    end

    return allowed
end

hook.Add('LVS.CanPlayerDrive', 'Whitelist', function(ply, vehicle)
    if (not IsValid(vehicle)) then return end

    if (not canPlayerControlVehicle(ply, vehicle)) then
        return false
    end
end)

hook.Add('LVS.OnPlayerCannotDrive', 'Whitelist', function(ply, vehicle)
    doNotify(ply, vehicle)
end)
```