### PR TITLE
Adding a check on the need for damage to the vehicle

### DIFF
--- a/lua/entities/lvs_base/init.lua
+++ b/lua/entities/lvs_base/init.lua
@@ -270,10 +270,12 @@ function ENT:Use( ply )
 end
 
 function ENT:OnTakeDamage( dmginfo )
-	self:CalcShieldDamage( dmginfo )
-	self:CalcDamage( dmginfo )
-	self:TakePhysicsDamage( dmginfo )
-	self:OnAITakeDamage( dmginfo )
+	if hook.Run( "LVS.CanTakeDamage", dmginfo, self ) ~= false then
+		self:CalcShieldDamage( dmginfo )
+		self:CalcDamage( dmginfo )
+		self:TakePhysicsDamage( dmginfo )
+		self:OnAITakeDamage( dmginfo )
+	end
 end
 
 function ENT:OnMaintenance()


### PR DESCRIPTION
I think it's cool to be able to manipulate whether a certain vehicle should take damage from regular shots or only from RPG shots.

At a minimum, with this hook it will be possible to remove damage to spaceships from ordinary bullets.

Please forgive me if I haven't noticed the presence of this hook yet.